### PR TITLE
Add eleven function terms for security-relevant classification

### DIFF
--- a/combined-taxonomy.json
+++ b/combined-taxonomy.json
@@ -1125,6 +1125,36 @@
       ]
     },
     {
+      "name": "bundling",
+      "description": "Combining and transforming source files into optimised deployable artifacts.",
+      "examples": [
+        "webpack",
+        "vite",
+        "esbuild",
+        "rollup",
+        "parcel"
+      ],
+      "related": [
+        "deployment",
+        "compression"
+      ],
+      "aliases": [
+        "module-bundling",
+        "asset-pipeline",
+        "asset-bundling"
+      ],
+      "ecosystems": [
+        "npm"
+      ],
+      "tags": [
+        "bundler",
+        "assets",
+        "modules",
+        "tree-shaking",
+        "minification"
+      ]
+    },
+    {
       "name": "caching",
       "description": "Cache systems, in-memory data stores, and performance optimization tools.",
       "examples": [
@@ -1177,6 +1207,39 @@
         "automation",
         "deployment",
         "pipelines"
+      ]
+    },
+    {
+      "name": "code-generation",
+      "description": "Tools that generate source code from schemas, interface definitions, or annotations.",
+      "examples": [
+        "protoc",
+        "openapi-generator",
+        "sqlc",
+        "graphql-codegen"
+      ],
+      "related": [
+        "api-development",
+        "serialization",
+        "automation"
+      ],
+      "aliases": [
+        "codegen",
+        "source-generation"
+      ],
+      "ecosystems": [
+        "npm",
+        "go",
+        "pypi",
+        "maven",
+        "cargo"
+      ],
+      "tags": [
+        "codegen",
+        "schema",
+        "idl",
+        "protobuf",
+        "openapi"
       ]
     },
     {
@@ -1239,6 +1302,43 @@
       ]
     },
     {
+      "name": "data-mapping",
+      "description": "Object-relational mappers and query builders that translate between application objects and database rows.",
+      "examples": [
+        "sqlalchemy",
+        "activerecord",
+        "prisma",
+        "gorm",
+        "diesel"
+      ],
+      "related": [
+        "database-management",
+        "data-layer",
+        "validation"
+      ],
+      "aliases": [
+        "orm",
+        "object-relational-mapping",
+        "query-builder"
+      ],
+      "ecosystems": [
+        "pypi",
+        "rubygems",
+        "npm",
+        "go",
+        "cargo",
+        "maven",
+        "packagist"
+      ],
+      "tags": [
+        "orm",
+        "database",
+        "sql",
+        "persistence",
+        "models"
+      ]
+    },
+    {
       "name": "database-management",
       "description": "Database administration tools, GUI clients, and database operation utilities.",
       "examples": [
@@ -1264,6 +1364,38 @@
         "admin",
         "management",
         "gui"
+      ]
+    },
+    {
+      "name": "dependency-injection",
+      "description": "Inversion of control containers that wire object graphs and manage component lifecycles.",
+      "examples": [
+        "guice",
+        "dagger",
+        "wire",
+        "inversify"
+      ],
+      "related": [
+        "testing",
+        "api-development"
+      ],
+      "aliases": [
+        "ioc",
+        "inversion-of-control",
+        "di-container"
+      ],
+      "ecosystems": [
+        "maven",
+        "npm",
+        "go",
+        "nuget"
+      ],
+      "tags": [
+        "injection",
+        "ioc",
+        "container",
+        "wiring",
+        "lifecycle"
       ]
     },
     {
@@ -1355,6 +1487,39 @@
       ]
     },
     {
+      "name": "feature-flags",
+      "description": "Runtime feature toggling for gradual rollouts, experiments, and kill switches.",
+      "examples": [
+        "launchdarkly",
+        "unleash",
+        "flipper",
+        "flagsmith"
+      ],
+      "related": [
+        "deployment",
+        "monitoring"
+      ],
+      "aliases": [
+        "feature-toggles",
+        "feature-management",
+        "feature-switches"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "rubygems",
+        "go",
+        "maven"
+      ],
+      "tags": [
+        "flags",
+        "toggles",
+        "rollout",
+        "experiments",
+        "configuration"
+      ]
+    },
+    {
       "name": "file-management",
       "description": "File operations, synchronization, backup, and filesystem utilities.",
       "examples": [
@@ -1382,6 +1547,43 @@
         "sync",
         "backup",
         "filesystem"
+      ]
+    },
+    {
+      "name": "http-client",
+      "description": "Libraries for making outbound HTTP requests to APIs and remote services.",
+      "examples": [
+        "requests",
+        "axios",
+        "reqwest",
+        "faraday",
+        "guzzle"
+      ],
+      "related": [
+        "api-development",
+        "networking",
+        "scraping"
+      ],
+      "aliases": [
+        "http-requests",
+        "rest-client",
+        "api-client"
+      ],
+      "ecosystems": [
+        "pypi",
+        "npm",
+        "cargo",
+        "rubygems",
+        "go",
+        "maven",
+        "packagist"
+      ],
+      "tags": [
+        "http",
+        "rest",
+        "api",
+        "client",
+        "requests"
       ]
     },
     {
@@ -1501,6 +1703,39 @@
       ]
     },
     {
+      "name": "mocking",
+      "description": "Test doubles, stubs, and fake implementations for isolating code under test.",
+      "examples": [
+        "mockito",
+        "sinon",
+        "msw",
+        "mockgen"
+      ],
+      "related": [
+        "testing",
+        "dependency-injection"
+      ],
+      "aliases": [
+        "test-doubles",
+        "stubbing",
+        "faking"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "maven",
+        "go",
+        "rubygems"
+      ],
+      "tags": [
+        "mocks",
+        "stubs",
+        "fakes",
+        "testing",
+        "isolation"
+      ]
+    },
+    {
       "name": "monitoring",
       "description": "Observability platforms, metrics collection, and system monitoring tools.",
       "examples": [
@@ -1587,6 +1822,38 @@
       ]
     },
     {
+      "name": "process-execution",
+      "description": "Libraries for spawning and managing operating system processes from application code.",
+      "examples": [
+        "execa",
+        "shelljs",
+        "sh",
+        "invoke"
+      ],
+      "related": [
+        "automation",
+        "file-management"
+      ],
+      "aliases": [
+        "subprocess",
+        "shell-execution",
+        "command-execution"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "rubygems",
+        "go"
+      ],
+      "tags": [
+        "subprocess",
+        "shell",
+        "exec",
+        "spawn",
+        "command"
+      ]
+    },
+    {
       "name": "scheduling",
       "description": "Task scheduling, cron jobs, and time-based automation for running tasks at specified intervals.",
       "examples": [
@@ -1667,6 +1934,77 @@
         "indexing",
         "full-text",
         "query"
+      ]
+    },
+    {
+      "name": "secrets-management",
+      "description": "Loading, storing, and rotating credentials and sensitive configuration at runtime.",
+      "examples": [
+        "vault",
+        "sops",
+        "dotenv",
+        "doppler"
+      ],
+      "related": [
+        "encryption",
+        "authentication",
+        "deployment"
+      ],
+      "aliases": [
+        "credential-management",
+        "secrets",
+        "secret-storage"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "go",
+        "rubygems",
+        "homebrew"
+      ],
+      "tags": [
+        "secrets",
+        "credentials",
+        "vault",
+        "environment",
+        "configuration"
+      ]
+    },
+    {
+      "name": "security-scanning",
+      "description": "Static and dynamic analysis tools that find vulnerabilities, secrets, and known-bad dependencies.",
+      "examples": [
+        "semgrep",
+        "trivy",
+        "bandit",
+        "brakeman",
+        "snyk"
+      ],
+      "related": [
+        "testing",
+        "ci-cd",
+        "validation"
+      ],
+      "aliases": [
+        "vulnerability-scanning",
+        "sast",
+        "sca",
+        "security-analysis"
+      ],
+      "ecosystems": [
+        "pypi",
+        "npm",
+        "rubygems",
+        "go",
+        "homebrew",
+        "docker"
+      ],
+      "tags": [
+        "security",
+        "vulnerabilities",
+        "scanning",
+        "static-analysis",
+        "cve"
       ]
     },
     {
@@ -1811,6 +2149,36 @@
         "regex",
         "diff",
         "strings"
+      ]
+    },
+    {
+      "name": "type-checking",
+      "description": "Static type analysis that verifies type correctness without running the code.",
+      "examples": [
+        "mypy",
+        "typescript",
+        "sorbet",
+        "pyright"
+      ],
+      "related": [
+        "validation",
+        "testing"
+      ],
+      "aliases": [
+        "static-typing",
+        "type-inference",
+        "typecheck"
+      ],
+      "ecosystems": [
+        "pypi",
+        "npm",
+        "rubygems"
+      ],
+      "tags": [
+        "types",
+        "static-analysis",
+        "type-safety",
+        "inference"
       ]
     },
     {

--- a/docs/combined-taxonomy.json
+++ b/docs/combined-taxonomy.json
@@ -1125,6 +1125,36 @@
       ]
     },
     {
+      "name": "bundling",
+      "description": "Combining and transforming source files into optimised deployable artifacts.",
+      "examples": [
+        "webpack",
+        "vite",
+        "esbuild",
+        "rollup",
+        "parcel"
+      ],
+      "related": [
+        "deployment",
+        "compression"
+      ],
+      "aliases": [
+        "module-bundling",
+        "asset-pipeline",
+        "asset-bundling"
+      ],
+      "ecosystems": [
+        "npm"
+      ],
+      "tags": [
+        "bundler",
+        "assets",
+        "modules",
+        "tree-shaking",
+        "minification"
+      ]
+    },
+    {
       "name": "caching",
       "description": "Cache systems, in-memory data stores, and performance optimization tools.",
       "examples": [
@@ -1177,6 +1207,39 @@
         "automation",
         "deployment",
         "pipelines"
+      ]
+    },
+    {
+      "name": "code-generation",
+      "description": "Tools that generate source code from schemas, interface definitions, or annotations.",
+      "examples": [
+        "protoc",
+        "openapi-generator",
+        "sqlc",
+        "graphql-codegen"
+      ],
+      "related": [
+        "api-development",
+        "serialization",
+        "automation"
+      ],
+      "aliases": [
+        "codegen",
+        "source-generation"
+      ],
+      "ecosystems": [
+        "npm",
+        "go",
+        "pypi",
+        "maven",
+        "cargo"
+      ],
+      "tags": [
+        "codegen",
+        "schema",
+        "idl",
+        "protobuf",
+        "openapi"
       ]
     },
     {
@@ -1239,6 +1302,43 @@
       ]
     },
     {
+      "name": "data-mapping",
+      "description": "Object-relational mappers and query builders that translate between application objects and database rows.",
+      "examples": [
+        "sqlalchemy",
+        "activerecord",
+        "prisma",
+        "gorm",
+        "diesel"
+      ],
+      "related": [
+        "database-management",
+        "data-layer",
+        "validation"
+      ],
+      "aliases": [
+        "orm",
+        "object-relational-mapping",
+        "query-builder"
+      ],
+      "ecosystems": [
+        "pypi",
+        "rubygems",
+        "npm",
+        "go",
+        "cargo",
+        "maven",
+        "packagist"
+      ],
+      "tags": [
+        "orm",
+        "database",
+        "sql",
+        "persistence",
+        "models"
+      ]
+    },
+    {
       "name": "database-management",
       "description": "Database administration tools, GUI clients, and database operation utilities.",
       "examples": [
@@ -1264,6 +1364,38 @@
         "admin",
         "management",
         "gui"
+      ]
+    },
+    {
+      "name": "dependency-injection",
+      "description": "Inversion of control containers that wire object graphs and manage component lifecycles.",
+      "examples": [
+        "guice",
+        "dagger",
+        "wire",
+        "inversify"
+      ],
+      "related": [
+        "testing",
+        "api-development"
+      ],
+      "aliases": [
+        "ioc",
+        "inversion-of-control",
+        "di-container"
+      ],
+      "ecosystems": [
+        "maven",
+        "npm",
+        "go",
+        "nuget"
+      ],
+      "tags": [
+        "injection",
+        "ioc",
+        "container",
+        "wiring",
+        "lifecycle"
       ]
     },
     {
@@ -1355,6 +1487,39 @@
       ]
     },
     {
+      "name": "feature-flags",
+      "description": "Runtime feature toggling for gradual rollouts, experiments, and kill switches.",
+      "examples": [
+        "launchdarkly",
+        "unleash",
+        "flipper",
+        "flagsmith"
+      ],
+      "related": [
+        "deployment",
+        "monitoring"
+      ],
+      "aliases": [
+        "feature-toggles",
+        "feature-management",
+        "feature-switches"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "rubygems",
+        "go",
+        "maven"
+      ],
+      "tags": [
+        "flags",
+        "toggles",
+        "rollout",
+        "experiments",
+        "configuration"
+      ]
+    },
+    {
       "name": "file-management",
       "description": "File operations, synchronization, backup, and filesystem utilities.",
       "examples": [
@@ -1382,6 +1547,43 @@
         "sync",
         "backup",
         "filesystem"
+      ]
+    },
+    {
+      "name": "http-client",
+      "description": "Libraries for making outbound HTTP requests to APIs and remote services.",
+      "examples": [
+        "requests",
+        "axios",
+        "reqwest",
+        "faraday",
+        "guzzle"
+      ],
+      "related": [
+        "api-development",
+        "networking",
+        "scraping"
+      ],
+      "aliases": [
+        "http-requests",
+        "rest-client",
+        "api-client"
+      ],
+      "ecosystems": [
+        "pypi",
+        "npm",
+        "cargo",
+        "rubygems",
+        "go",
+        "maven",
+        "packagist"
+      ],
+      "tags": [
+        "http",
+        "rest",
+        "api",
+        "client",
+        "requests"
       ]
     },
     {
@@ -1501,6 +1703,39 @@
       ]
     },
     {
+      "name": "mocking",
+      "description": "Test doubles, stubs, and fake implementations for isolating code under test.",
+      "examples": [
+        "mockito",
+        "sinon",
+        "msw",
+        "mockgen"
+      ],
+      "related": [
+        "testing",
+        "dependency-injection"
+      ],
+      "aliases": [
+        "test-doubles",
+        "stubbing",
+        "faking"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "maven",
+        "go",
+        "rubygems"
+      ],
+      "tags": [
+        "mocks",
+        "stubs",
+        "fakes",
+        "testing",
+        "isolation"
+      ]
+    },
+    {
       "name": "monitoring",
       "description": "Observability platforms, metrics collection, and system monitoring tools.",
       "examples": [
@@ -1587,6 +1822,38 @@
       ]
     },
     {
+      "name": "process-execution",
+      "description": "Libraries for spawning and managing operating system processes from application code.",
+      "examples": [
+        "execa",
+        "shelljs",
+        "sh",
+        "invoke"
+      ],
+      "related": [
+        "automation",
+        "file-management"
+      ],
+      "aliases": [
+        "subprocess",
+        "shell-execution",
+        "command-execution"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "rubygems",
+        "go"
+      ],
+      "tags": [
+        "subprocess",
+        "shell",
+        "exec",
+        "spawn",
+        "command"
+      ]
+    },
+    {
       "name": "scheduling",
       "description": "Task scheduling, cron jobs, and time-based automation for running tasks at specified intervals.",
       "examples": [
@@ -1667,6 +1934,77 @@
         "indexing",
         "full-text",
         "query"
+      ]
+    },
+    {
+      "name": "secrets-management",
+      "description": "Loading, storing, and rotating credentials and sensitive configuration at runtime.",
+      "examples": [
+        "vault",
+        "sops",
+        "dotenv",
+        "doppler"
+      ],
+      "related": [
+        "encryption",
+        "authentication",
+        "deployment"
+      ],
+      "aliases": [
+        "credential-management",
+        "secrets",
+        "secret-storage"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "go",
+        "rubygems",
+        "homebrew"
+      ],
+      "tags": [
+        "secrets",
+        "credentials",
+        "vault",
+        "environment",
+        "configuration"
+      ]
+    },
+    {
+      "name": "security-scanning",
+      "description": "Static and dynamic analysis tools that find vulnerabilities, secrets, and known-bad dependencies.",
+      "examples": [
+        "semgrep",
+        "trivy",
+        "bandit",
+        "brakeman",
+        "snyk"
+      ],
+      "related": [
+        "testing",
+        "ci-cd",
+        "validation"
+      ],
+      "aliases": [
+        "vulnerability-scanning",
+        "sast",
+        "sca",
+        "security-analysis"
+      ],
+      "ecosystems": [
+        "pypi",
+        "npm",
+        "rubygems",
+        "go",
+        "homebrew",
+        "docker"
+      ],
+      "tags": [
+        "security",
+        "vulnerabilities",
+        "scanning",
+        "static-analysis",
+        "cve"
       ]
     },
     {
@@ -1811,6 +2149,36 @@
         "regex",
         "diff",
         "strings"
+      ]
+    },
+    {
+      "name": "type-checking",
+      "description": "Static type analysis that verifies type correctness without running the code.",
+      "examples": [
+        "mypy",
+        "typescript",
+        "sorbet",
+        "pyright"
+      ],
+      "related": [
+        "validation",
+        "testing"
+      ],
+      "aliases": [
+        "static-typing",
+        "type-inference",
+        "typecheck"
+      ],
+      "ecosystems": [
+        "pypi",
+        "npm",
+        "rubygems"
+      ],
+      "tags": [
+        "types",
+        "static-analysis",
+        "type-safety",
+        "inference"
       ]
     },
     {

--- a/oss-taxonomy/function/bundling.yml
+++ b/oss-taxonomy/function/bundling.yml
@@ -1,0 +1,23 @@
+name: bundling
+description: Combining and transforming source files into optimised deployable artifacts.
+examples:
+  - webpack
+  - vite
+  - esbuild
+  - rollup
+  - parcel
+related:
+  - deployment
+  - compression
+aliases:
+  - module-bundling
+  - asset-pipeline
+  - asset-bundling
+ecosystems:
+  - npm
+tags:
+  - bundler
+  - assets
+  - modules
+  - tree-shaking
+  - minification

--- a/oss-taxonomy/function/code-generation.yml
+++ b/oss-taxonomy/function/code-generation.yml
@@ -1,0 +1,26 @@
+name: code-generation
+description: Tools that generate source code from schemas, interface definitions, or annotations.
+examples:
+  - protoc
+  - openapi-generator
+  - sqlc
+  - graphql-codegen
+related:
+  - api-development
+  - serialization
+  - automation
+aliases:
+  - codegen
+  - source-generation
+ecosystems:
+  - npm
+  - go
+  - pypi
+  - maven
+  - cargo
+tags:
+  - codegen
+  - schema
+  - idl
+  - protobuf
+  - openapi

--- a/oss-taxonomy/function/data-mapping.yml
+++ b/oss-taxonomy/function/data-mapping.yml
@@ -1,0 +1,30 @@
+name: data-mapping
+description: Object-relational mappers and query builders that translate between application objects and database rows.
+examples:
+  - sqlalchemy
+  - activerecord
+  - prisma
+  - gorm
+  - diesel
+related:
+  - database-management
+  - data-layer
+  - validation
+aliases:
+  - orm
+  - object-relational-mapping
+  - query-builder
+ecosystems:
+  - pypi
+  - rubygems
+  - npm
+  - go
+  - cargo
+  - maven
+  - packagist
+tags:
+  - orm
+  - database
+  - sql
+  - persistence
+  - models

--- a/oss-taxonomy/function/dependency-injection.yml
+++ b/oss-taxonomy/function/dependency-injection.yml
@@ -1,0 +1,25 @@
+name: dependency-injection
+description: Inversion of control containers that wire object graphs and manage component lifecycles.
+examples:
+  - guice
+  - dagger
+  - wire
+  - inversify
+related:
+  - testing
+  - api-development
+aliases:
+  - ioc
+  - inversion-of-control
+  - di-container
+ecosystems:
+  - maven
+  - npm
+  - go
+  - nuget
+tags:
+  - injection
+  - ioc
+  - container
+  - wiring
+  - lifecycle

--- a/oss-taxonomy/function/feature-flags.yml
+++ b/oss-taxonomy/function/feature-flags.yml
@@ -1,0 +1,26 @@
+name: feature-flags
+description: Runtime feature toggling for gradual rollouts, experiments, and kill switches.
+examples:
+  - launchdarkly
+  - unleash
+  - flipper
+  - flagsmith
+related:
+  - deployment
+  - monitoring
+aliases:
+  - feature-toggles
+  - feature-management
+  - feature-switches
+ecosystems:
+  - npm
+  - pypi
+  - rubygems
+  - go
+  - maven
+tags:
+  - flags
+  - toggles
+  - rollout
+  - experiments
+  - configuration

--- a/oss-taxonomy/function/http-client.yml
+++ b/oss-taxonomy/function/http-client.yml
@@ -1,0 +1,30 @@
+name: http-client
+description: Libraries for making outbound HTTP requests to APIs and remote services.
+examples:
+  - requests
+  - axios
+  - reqwest
+  - faraday
+  - guzzle
+related:
+  - api-development
+  - networking
+  - scraping
+aliases:
+  - http-requests
+  - rest-client
+  - api-client
+ecosystems:
+  - pypi
+  - npm
+  - cargo
+  - rubygems
+  - go
+  - maven
+  - packagist
+tags:
+  - http
+  - rest
+  - api
+  - client
+  - requests

--- a/oss-taxonomy/function/mocking.yml
+++ b/oss-taxonomy/function/mocking.yml
@@ -1,0 +1,26 @@
+name: mocking
+description: Test doubles, stubs, and fake implementations for isolating code under test.
+examples:
+  - mockito
+  - sinon
+  - msw
+  - mockgen
+related:
+  - testing
+  - dependency-injection
+aliases:
+  - test-doubles
+  - stubbing
+  - faking
+ecosystems:
+  - npm
+  - pypi
+  - maven
+  - go
+  - rubygems
+tags:
+  - mocks
+  - stubs
+  - fakes
+  - testing
+  - isolation

--- a/oss-taxonomy/function/process-execution.yml
+++ b/oss-taxonomy/function/process-execution.yml
@@ -1,0 +1,25 @@
+name: process-execution
+description: Libraries for spawning and managing operating system processes from application code.
+examples:
+  - execa
+  - shelljs
+  - sh
+  - invoke
+related:
+  - automation
+  - file-management
+aliases:
+  - subprocess
+  - shell-execution
+  - command-execution
+ecosystems:
+  - npm
+  - pypi
+  - rubygems
+  - go
+tags:
+  - subprocess
+  - shell
+  - exec
+  - spawn
+  - command

--- a/oss-taxonomy/function/secrets-management.yml
+++ b/oss-taxonomy/function/secrets-management.yml
@@ -1,0 +1,27 @@
+name: secrets-management
+description: Loading, storing, and rotating credentials and sensitive configuration at runtime.
+examples:
+  - vault
+  - sops
+  - dotenv
+  - doppler
+related:
+  - encryption
+  - authentication
+  - deployment
+aliases:
+  - credential-management
+  - secrets
+  - secret-storage
+ecosystems:
+  - npm
+  - pypi
+  - go
+  - rubygems
+  - homebrew
+tags:
+  - secrets
+  - credentials
+  - vault
+  - environment
+  - configuration

--- a/oss-taxonomy/function/security-scanning.yml
+++ b/oss-taxonomy/function/security-scanning.yml
@@ -1,0 +1,30 @@
+name: security-scanning
+description: Static and dynamic analysis tools that find vulnerabilities, secrets, and known-bad dependencies.
+examples:
+  - semgrep
+  - trivy
+  - bandit
+  - brakeman
+  - snyk
+related:
+  - testing
+  - ci-cd
+  - validation
+aliases:
+  - vulnerability-scanning
+  - sast
+  - sca
+  - security-analysis
+ecosystems:
+  - pypi
+  - npm
+  - rubygems
+  - go
+  - homebrew
+  - docker
+tags:
+  - security
+  - vulnerabilities
+  - scanning
+  - static-analysis
+  - cve

--- a/oss-taxonomy/function/type-checking.yml
+++ b/oss-taxonomy/function/type-checking.yml
@@ -1,0 +1,23 @@
+name: type-checking
+description: Static type analysis that verifies type correctness without running the code.
+examples:
+  - mypy
+  - typescript
+  - sorbet
+  - pyright
+related:
+  - validation
+  - testing
+aliases:
+  - static-typing
+  - type-inference
+  - typecheck
+ecosystems:
+  - pypi
+  - npm
+  - rubygems
+tags:
+  - types
+  - static-analysis
+  - type-safety
+  - inference


### PR DESCRIPTION
New terms covering gaps found while classifying the brief tool definitions: `data-mapping` (ORMs, distinct from `database-management` which is admin GUIs), `http-client` (request libraries, distinct from `networking` which is wireshark/iptables), `code-generation`, `security-scanning`, `type-checking`, `process-execution`, `feature-flags`, `secrets-management`, `dependency-injection`, `mocking`, `bundling`. Function facet goes from 29 to 40 terms.

Skipped `routing` and `migrations` from the issue since they may already be covered by `api-development` + `role:framework` and `database-management` respectively.

Closes #10