### PR TITLE
Align lint field list with schema.json

### DIFF
--- a/lint_yml_files.rb
+++ b/lint_yml_files.rb
@@ -2,8 +2,8 @@ require 'bundler/setup'
 require 'yaml'
 require 'fileutils'
 
-required_fields = ['name', 'description', 'examples']
-optional_fields = ['aliases', 'notable_projects', 'ecosystems', 'tags']
+required_fields = ['name', 'description']
+optional_fields = ['examples', 'related', 'aliases', 'ecosystems', 'tags']
 
 facet_directories = Dir.glob('oss-taxonomy/*').select { |entry| File.directory?(entry) }
 


### PR DESCRIPTION
The lint was flagging every term file with "Extra fields found: related" because `related` was missing from `optional_fields`, despite being in `schema.json` and used by all 155 files. Also dropped `notable_projects` (nothing uses it, not in schema) and moved `examples` to optional to match the schema.

The lint still doesn't exit nonzero on error so it can't fail CI, but that's a separate change.