### PR TITLE
Make lint script exit nonzero on error

### DIFF
--- a/lint_yml_files.rb
+++ b/lint_yml_files.rb
@@ -7,6 +7,8 @@ optional_fields = ['examples', 'related', 'aliases', 'ecosystems', 'tags']
 
 facet_directories = Dir.glob('oss-taxonomy/*').select { |entry| File.directory?(entry) }
 
+errors = []
+
 facet_directories.each do |facet_dir|
   seen_names = []
 
@@ -21,28 +23,41 @@ facet_directories.each do |facet_dir|
       if missing_fields.empty?
         puts "  ✅ File is valid"
       else
-        puts "  ERROR: Missing required fields: #{missing_fields.join(', ')}"
+        errors << "#{file}: Missing required fields: #{missing_fields.join(', ')}"
+        puts "  ERROR: #{errors.last}"
       end
 
       extra_fields = content.keys.reject { |key| required_fields.include?(key) || optional_fields.include?(key) }
 
       unless extra_fields.empty?
-        puts "  ERROR: Extra fields found: #{extra_fields.join(', ')}"
+        errors << "#{file}: Extra fields found: #{extra_fields.join(', ')}"
+        puts "  ERROR: #{errors.last}"
       end
 
       if seen_names.include?(content['name'])
-        puts "  ERROR: Duplicate name found: #{content['name']}"
+        errors << "#{file}: Duplicate name found: #{content['name']}"
+        puts "  ERROR: #{errors.last}"
       else
         seen_names << content['name']
       end
 
       filename = File.basename(file)
       if filename != filename.downcase
-        puts "  ERROR: Filename is not lowercase: #{filename}"
+        errors << "#{file}: Filename is not lowercase: #{filename}"
+        puts "  ERROR: #{errors.last}"
       end
 
     rescue => e
-      puts "  ERROR: Could not parse YAML file #{file}: #{e.message}"
+      errors << "#{file}: Could not parse YAML: #{e.message}"
+      puts "  ERROR: #{errors.last}"
     end
   end
 end
+
+if errors.any?
+  puts "\n#{errors.length} error(s):"
+  errors.each { |e| puts "  #{e}" }
+  exit 1
+end
+
+puts "\nAll files valid."


### PR DESCRIPTION
The `lint.yml` workflow has been running on PRs but always passing because the script never set an exit code. Now collects errors, prints a summary at the end with file paths, and exits 1. Rebased on top of #14 so lint passes clean on current main (166 files, 0 errors).