### PR TITLE
Harden workflows per zizmor findings

### DIFF
--- a/.github/workflows/combine-yml.yml
+++ b/.github/workflows/combine-yml.yml
@@ -5,31 +5,28 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   combine_yml_to_json:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4 # zizmor: ignore[artipacked] add-and-commit needs the token to push
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
-          ruby-version: 3.0
+          ruby-version: '3.4'
           bundler-cache: true
 
-      - name: Install dependencies with Bundler
-        run: |
-          gem install bundler
-          bundle install
-
       - name: Run combine script
-        run: |
-          bundle exec ruby ./combine_yml_to_json.rb
-          
+        run: bundle exec ruby ./combine_yml_to_json.rb
+
       - name: Commit and push changes
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           message: 'Update combined-taxonomy.json'
-          add: 'combined-taxonomy.json'
+          add: 'combined-taxonomy.json terms.txt docs/'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,24 +7,23 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
-          ruby-version: 3.0
+          ruby-version: '3.4'
           bundler-cache: true
 
-      - name: Install dependencies with Bundler
-        run: |
-          gem install bundler
-          bundle install
-
       - name: Run YML linting
-        run: |
-          bundle exec ruby ./lint_yml_files.rb
+        run: bundle exec ruby ./lint_yml_files.rb


### PR DESCRIPTION
Pinned third-party actions to commit SHAs (`ruby/setup-ruby`, `EndBug/add-and-commit`), added explicit `permissions` blocks, set `persist-credentials: false` on checkouts that don't push back, bumped checkout v2→v4 and Ruby 3.0→3.4. Dropped the redundant `bundle install` step since `bundler-cache: true` on setup-ruby already does it. Also fixed the `add` list in combine-yml to include `terms.txt` and `docs/` since the combine script writes those now.

zizmor clean apart from one intentional ignore where add-and-commit needs the checkout token.