### PR TITLE
Add six function terms found while classifying brief tool definitions

### DIFF
--- a/combined-taxonomy.json
+++ b/combined-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "generated_at": "2026-04-11T10:27:17Z",
+  "generated_at": "2026-04-11T15:18:36Z",
   "audience": [
     {
       "name": "content-creator",
@@ -1127,6 +1127,41 @@
       ]
     },
     {
+      "name": "benchmarking",
+      "description": "Measuring execution time, throughput, or resource usage of code under controlled conditions.",
+      "examples": [
+        "criterion",
+        "hyperfine",
+        "k6",
+        "gatling",
+        "locust"
+      ],
+      "related": [
+        "testing",
+        "monitoring"
+      ],
+      "aliases": [
+        "performance-testing",
+        "load-testing",
+        "micro-benchmarking"
+      ],
+      "ecosystems": [
+        "cargo",
+        "homebrew",
+        "pypi",
+        "maven",
+        "npm",
+        "rubygems"
+      ],
+      "tags": [
+        "performance",
+        "benchmarks",
+        "latency",
+        "throughput",
+        "profiling"
+      ]
+    },
+    {
       "name": "bundling",
       "description": "Combining and transforming source files into optimised deployable artifacts.",
       "examples": [
@@ -1301,6 +1336,38 @@
         "docker",
         "images",
         "runtime"
+      ]
+    },
+    {
+      "name": "coverage",
+      "description": "Measuring which lines, branches, or paths of code are exercised by tests.",
+      "examples": [
+        "simplecov",
+        "jacoco",
+        "istanbul",
+        "tarpaulin"
+      ],
+      "related": [
+        "testing",
+        "ci-cd"
+      ],
+      "aliases": [
+        "code-coverage",
+        "test-coverage"
+      ],
+      "ecosystems": [
+        "rubygems",
+        "maven",
+        "npm",
+        "cargo",
+        "pypi",
+        "go"
+      ],
+      "tags": [
+        "coverage",
+        "metrics",
+        "testing",
+        "reporting"
       ]
     },
     {
@@ -1856,6 +1923,70 @@
       ]
     },
     {
+      "name": "release-management",
+      "description": "Versioning, changelog generation, and publishing automation for software releases.",
+      "examples": [
+        "semantic-release",
+        "changesets",
+        "release-please",
+        "goreleaser"
+      ],
+      "related": [
+        "ci-cd",
+        "automation",
+        "deployment"
+      ],
+      "aliases": [
+        "versioning",
+        "changelog",
+        "release-automation"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "cargo",
+        "go",
+        "actions"
+      ],
+      "tags": [
+        "releases",
+        "semver",
+        "changelog",
+        "publishing",
+        "tags"
+      ]
+    },
+    {
+      "name": "runtime-management",
+      "description": "Installing and switching between versions of language runtimes and toolchains.",
+      "examples": [
+        "asdf",
+        "mise",
+        "pyenv",
+        "nvm",
+        "rbenv"
+      ],
+      "related": [
+        "automation",
+        "deployment"
+      ],
+      "aliases": [
+        "version-manager",
+        "toolchain-management"
+      ],
+      "ecosystems": [
+        "homebrew",
+        "npm",
+        "pypi"
+      ],
+      "tags": [
+        "versions",
+        "runtimes",
+        "shims",
+        "toolchain"
+      ]
+    },
+    {
       "name": "scheduling",
       "description": "Task scheduling, cron jobs, and time-based automation for running tasks at specified intervals.",
       "examples": [
@@ -2065,6 +2196,70 @@
         "modeling",
         "analysis",
         "prediction"
+      ]
+    },
+    {
+      "name": "site-generation",
+      "description": "Building static websites from content files, templates, and data sources.",
+      "examples": [
+        "hugo",
+        "jekyll",
+        "eleventy",
+        "astro",
+        "gatsby"
+      ],
+      "related": [
+        "templating",
+        "documentation",
+        "bundling"
+      ],
+      "aliases": [
+        "static-site-generator",
+        "ssg",
+        "site-builder"
+      ],
+      "ecosystems": [
+        "npm",
+        "rubygems",
+        "go",
+        "pypi"
+      ],
+      "tags": [
+        "static-site",
+        "markdown",
+        "content",
+        "jamstack",
+        "prerendering"
+      ]
+    },
+    {
+      "name": "styling",
+      "description": "Processing, generating, or extending stylesheets and visual presentation rules.",
+      "examples": [
+        "sass",
+        "postcss",
+        "tailwindcss",
+        "less"
+      ],
+      "related": [
+        "templating",
+        "bundling"
+      ],
+      "aliases": [
+        "css-processing",
+        "stylesheet",
+        "css-preprocessing"
+      ],
+      "ecosystems": [
+        "npm",
+        "rubygems"
+      ],
+      "tags": [
+        "css",
+        "stylesheets",
+        "preprocessor",
+        "design-tokens",
+        "utility-classes"
       ]
     },
     {

--- a/docs/combined-taxonomy.json
+++ b/docs/combined-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "generated_at": "2026-04-11T10:27:17Z",
+  "generated_at": "2026-04-11T15:18:36Z",
   "audience": [
     {
       "name": "content-creator",
@@ -1127,6 +1127,41 @@
       ]
     },
     {
+      "name": "benchmarking",
+      "description": "Measuring execution time, throughput, or resource usage of code under controlled conditions.",
+      "examples": [
+        "criterion",
+        "hyperfine",
+        "k6",
+        "gatling",
+        "locust"
+      ],
+      "related": [
+        "testing",
+        "monitoring"
+      ],
+      "aliases": [
+        "performance-testing",
+        "load-testing",
+        "micro-benchmarking"
+      ],
+      "ecosystems": [
+        "cargo",
+        "homebrew",
+        "pypi",
+        "maven",
+        "npm",
+        "rubygems"
+      ],
+      "tags": [
+        "performance",
+        "benchmarks",
+        "latency",
+        "throughput",
+        "profiling"
+      ]
+    },
+    {
       "name": "bundling",
       "description": "Combining and transforming source files into optimised deployable artifacts.",
       "examples": [
@@ -1301,6 +1336,38 @@
         "docker",
         "images",
         "runtime"
+      ]
+    },
+    {
+      "name": "coverage",
+      "description": "Measuring which lines, branches, or paths of code are exercised by tests.",
+      "examples": [
+        "simplecov",
+        "jacoco",
+        "istanbul",
+        "tarpaulin"
+      ],
+      "related": [
+        "testing",
+        "ci-cd"
+      ],
+      "aliases": [
+        "code-coverage",
+        "test-coverage"
+      ],
+      "ecosystems": [
+        "rubygems",
+        "maven",
+        "npm",
+        "cargo",
+        "pypi",
+        "go"
+      ],
+      "tags": [
+        "coverage",
+        "metrics",
+        "testing",
+        "reporting"
       ]
     },
     {
@@ -1856,6 +1923,70 @@
       ]
     },
     {
+      "name": "release-management",
+      "description": "Versioning, changelog generation, and publishing automation for software releases.",
+      "examples": [
+        "semantic-release",
+        "changesets",
+        "release-please",
+        "goreleaser"
+      ],
+      "related": [
+        "ci-cd",
+        "automation",
+        "deployment"
+      ],
+      "aliases": [
+        "versioning",
+        "changelog",
+        "release-automation"
+      ],
+      "ecosystems": [
+        "npm",
+        "pypi",
+        "cargo",
+        "go",
+        "actions"
+      ],
+      "tags": [
+        "releases",
+        "semver",
+        "changelog",
+        "publishing",
+        "tags"
+      ]
+    },
+    {
+      "name": "runtime-management",
+      "description": "Installing and switching between versions of language runtimes and toolchains.",
+      "examples": [
+        "asdf",
+        "mise",
+        "pyenv",
+        "nvm",
+        "rbenv"
+      ],
+      "related": [
+        "automation",
+        "deployment"
+      ],
+      "aliases": [
+        "version-manager",
+        "toolchain-management"
+      ],
+      "ecosystems": [
+        "homebrew",
+        "npm",
+        "pypi"
+      ],
+      "tags": [
+        "versions",
+        "runtimes",
+        "shims",
+        "toolchain"
+      ]
+    },
+    {
       "name": "scheduling",
       "description": "Task scheduling, cron jobs, and time-based automation for running tasks at specified intervals.",
       "examples": [
@@ -2065,6 +2196,70 @@
         "modeling",
         "analysis",
         "prediction"
+      ]
+    },
+    {
+      "name": "site-generation",
+      "description": "Building static websites from content files, templates, and data sources.",
+      "examples": [
+        "hugo",
+        "jekyll",
+        "eleventy",
+        "astro",
+        "gatsby"
+      ],
+      "related": [
+        "templating",
+        "documentation",
+        "bundling"
+      ],
+      "aliases": [
+        "static-site-generator",
+        "ssg",
+        "site-builder"
+      ],
+      "ecosystems": [
+        "npm",
+        "rubygems",
+        "go",
+        "pypi"
+      ],
+      "tags": [
+        "static-site",
+        "markdown",
+        "content",
+        "jamstack",
+        "prerendering"
+      ]
+    },
+    {
+      "name": "styling",
+      "description": "Processing, generating, or extending stylesheets and visual presentation rules.",
+      "examples": [
+        "sass",
+        "postcss",
+        "tailwindcss",
+        "less"
+      ],
+      "related": [
+        "templating",
+        "bundling"
+      ],
+      "aliases": [
+        "css-processing",
+        "stylesheet",
+        "css-preprocessing"
+      ],
+      "ecosystems": [
+        "npm",
+        "rubygems"
+      ],
+      "tags": [
+        "css",
+        "stylesheets",
+        "preprocessor",
+        "design-tokens",
+        "utility-classes"
       ]
     },
     {

--- a/docs/terms.txt
+++ b/docs/terms.txt
@@ -37,12 +37,14 @@ domain:web-development
 function:api-development
 function:authentication
 function:automation
+function:benchmarking
 function:bundling
 function:caching
 function:ci-cd
 function:code-generation
 function:compression
 function:containerization
+function:coverage
 function:data-mapping
 function:database-management
 function:dependency-injection
@@ -61,6 +63,8 @@ function:monitoring
 function:networking
 function:parsing
 function:process-execution
+function:release-management
+function:runtime-management
 function:scheduling
 function:scraping
 function:search
@@ -68,6 +72,8 @@ function:secrets-management
 function:security-scanning
 function:serialization
 function:simulation
+function:site-generation
+function:styling
 function:templating
 function:testing
 function:text-processing

--- a/oss-taxonomy/function/benchmarking.yml
+++ b/oss-taxonomy/function/benchmarking.yml
@@ -1,0 +1,28 @@
+name: benchmarking
+description: Measuring execution time, throughput, or resource usage of code under controlled conditions.
+examples:
+  - criterion
+  - hyperfine
+  - k6
+  - gatling
+  - locust
+related:
+  - testing
+  - monitoring
+aliases:
+  - performance-testing
+  - load-testing
+  - micro-benchmarking
+ecosystems:
+  - cargo
+  - homebrew
+  - pypi
+  - maven
+  - npm
+  - rubygems
+tags:
+  - performance
+  - benchmarks
+  - latency
+  - throughput
+  - profiling

--- a/oss-taxonomy/function/coverage.yml
+++ b/oss-taxonomy/function/coverage.yml
@@ -1,0 +1,25 @@
+name: coverage
+description: Measuring which lines, branches, or paths of code are exercised by tests.
+examples:
+  - simplecov
+  - jacoco
+  - istanbul
+  - tarpaulin
+related:
+  - testing
+  - ci-cd
+aliases:
+  - code-coverage
+  - test-coverage
+ecosystems:
+  - rubygems
+  - maven
+  - npm
+  - cargo
+  - pypi
+  - go
+tags:
+  - coverage
+  - metrics
+  - testing
+  - reporting

--- a/oss-taxonomy/function/release-management.yml
+++ b/oss-taxonomy/function/release-management.yml
@@ -1,0 +1,27 @@
+name: release-management
+description: Versioning, changelog generation, and publishing automation for software releases.
+examples:
+  - semantic-release
+  - changesets
+  - release-please
+  - goreleaser
+related:
+  - ci-cd
+  - automation
+  - deployment
+aliases:
+  - versioning
+  - changelog
+  - release-automation
+ecosystems:
+  - npm
+  - pypi
+  - cargo
+  - go
+  - actions
+tags:
+  - releases
+  - semver
+  - changelog
+  - publishing
+  - tags

--- a/oss-taxonomy/function/runtime-management.yml
+++ b/oss-taxonomy/function/runtime-management.yml
@@ -1,0 +1,23 @@
+name: runtime-management
+description: Installing and switching between versions of language runtimes and toolchains.
+examples:
+  - asdf
+  - mise
+  - pyenv
+  - nvm
+  - rbenv
+related:
+  - automation
+  - deployment
+aliases:
+  - version-manager
+  - toolchain-management
+ecosystems:
+  - homebrew
+  - npm
+  - pypi
+tags:
+  - versions
+  - runtimes
+  - shims
+  - toolchain

--- a/oss-taxonomy/function/site-generation.yml
+++ b/oss-taxonomy/function/site-generation.yml
@@ -1,0 +1,27 @@
+name: site-generation
+description: Building static websites from content files, templates, and data sources.
+examples:
+  - hugo
+  - jekyll
+  - eleventy
+  - astro
+  - gatsby
+related:
+  - templating
+  - documentation
+  - bundling
+aliases:
+  - static-site-generator
+  - ssg
+  - site-builder
+ecosystems:
+  - npm
+  - rubygems
+  - go
+  - pypi
+tags:
+  - static-site
+  - markdown
+  - content
+  - jamstack
+  - prerendering

--- a/oss-taxonomy/function/styling.yml
+++ b/oss-taxonomy/function/styling.yml
@@ -1,0 +1,23 @@
+name: styling
+description: Processing, generating, or extending stylesheets and visual presentation rules.
+examples:
+  - sass
+  - postcss
+  - tailwindcss
+  - less
+related:
+  - templating
+  - bundling
+aliases:
+  - css-processing
+  - stylesheet
+  - css-preprocessing
+ecosystems:
+  - npm
+  - rubygems
+tags:
+  - css
+  - stylesheets
+  - preprocessor
+  - design-tokens
+  - utility-classes

--- a/terms.txt
+++ b/terms.txt
@@ -37,12 +37,14 @@ domain:web-development
 function:api-development
 function:authentication
 function:automation
+function:benchmarking
 function:bundling
 function:caching
 function:ci-cd
 function:code-generation
 function:compression
 function:containerization
+function:coverage
 function:data-mapping
 function:database-management
 function:dependency-injection
@@ -61,6 +63,8 @@ function:monitoring
 function:networking
 function:parsing
 function:process-execution
+function:release-management
+function:runtime-management
 function:scheduling
 function:scraping
 function:search
@@ -68,6 +72,8 @@ function:secrets-management
 function:security-scanning
 function:serialization
 function:simulation
+function:site-generation
+function:styling
 function:templating
 function:testing
 function:text-processing


### PR DESCRIPTION
Tagging the 446 brief tool definitions surfaced gaps where the closest existing term was lossy. Coverage tools (simplecov, jacoco, tarpaulin) went under `testing`. Benchmarks and load testers (criterion, k6, gatling) went under `testing-framework`. Release automation (semantic-release, changesets, goreleaser) went under `deployment` which is wrong since they version and changelog rather than deploy. Version managers (asdf, mise, pyenv) got bare `role:cli-tool` with no function at all. CSS preprocessors (sass, postcss, tailwind) got `layer:frontend` with nothing functional. Static site generators (hugo, jekyll, astro) got `templating` which understates the data fetching, routing, and asset pipeline parts.

Function facet goes from 40 to 46 terms. About 40 tool defs in brief would get retagged once these land.