### PR TITLE
Add native-extension role

### DIFF
--- a/combined-taxonomy.json
+++ b/combined-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "generated_at": "2026-07-09T13:20:20Z",
+  "generated_at": "2026-07-09T14:50:32Z",
   "audience": [
     {
       "name": "content-creator",
@@ -3906,7 +3906,7 @@
     },
     {
       "name": "native-extension",
-      "description": "Packages that compile C, C++, or Rust into a shared object the host language runtime loads at import time.",
+      "description": "Packages that load compiled C, C++, or Rust code as a shared library (.so/.dylib/.dll) into the host language runtime at import time, whether built from bundled source during install or shipped as a prebuilt binary.",
       "examples": [
         "nokogiri",
         "numpy",

--- a/combined-taxonomy.json
+++ b/combined-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "generated_at": "2026-06-29T08:38:53Z",
+  "generated_at": "2026-07-09T13:20:20Z",
   "audience": [
     {
       "name": "content-creator",
@@ -3902,6 +3902,43 @@
         "static-analysis",
         "style",
         "errors"
+      ]
+    },
+    {
+      "name": "native-extension",
+      "description": "Packages that compile C, C++, or Rust into a shared object the host language runtime loads at import time.",
+      "examples": [
+        "nokogiri",
+        "numpy",
+        "psycopg2",
+        "node-sass",
+        "bcrypt",
+        "grpcio"
+      ],
+      "related": [
+        "library",
+        "plugin",
+        "build-tool"
+      ],
+      "aliases": [
+        "c-extension",
+        "native-addon",
+        "ffi-binding",
+        "compiled-extension"
+      ],
+      "ecosystems": [
+        "rubygems",
+        "pypi",
+        "npm",
+        "packagist",
+        "hex",
+        "cpan"
+      ],
+      "tags": [
+        "ffi",
+        "native",
+        "compiled",
+        "binding"
       ]
     },
     {

--- a/docs/combined-taxonomy.json
+++ b/docs/combined-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "generated_at": "2026-07-09T13:20:20Z",
+  "generated_at": "2026-07-09T14:50:32Z",
   "audience": [
     {
       "name": "content-creator",
@@ -3906,7 +3906,7 @@
     },
     {
       "name": "native-extension",
-      "description": "Packages that compile C, C++, or Rust into a shared object the host language runtime loads at import time.",
+      "description": "Packages that load compiled C, C++, or Rust code as a shared library (.so/.dylib/.dll) into the host language runtime at import time, whether built from bundled source during install or shipped as a prebuilt binary.",
       "examples": [
         "nokogiri",
         "numpy",

--- a/docs/combined-taxonomy.json
+++ b/docs/combined-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "generated_at": "2026-06-29T08:38:53Z",
+  "generated_at": "2026-07-09T13:20:20Z",
   "audience": [
     {
       "name": "content-creator",
@@ -3902,6 +3902,43 @@
         "static-analysis",
         "style",
         "errors"
+      ]
+    },
+    {
+      "name": "native-extension",
+      "description": "Packages that compile C, C++, or Rust into a shared object the host language runtime loads at import time.",
+      "examples": [
+        "nokogiri",
+        "numpy",
+        "psycopg2",
+        "node-sass",
+        "bcrypt",
+        "grpcio"
+      ],
+      "related": [
+        "library",
+        "plugin",
+        "build-tool"
+      ],
+      "aliases": [
+        "c-extension",
+        "native-addon",
+        "ffi-binding",
+        "compiled-extension"
+      ],
+      "ecosystems": [
+        "rubygems",
+        "pypi",
+        "npm",
+        "packagist",
+        "hex",
+        "cpan"
+      ],
+      "tags": [
+        "ffi",
+        "native",
+        "compiled",
+        "binding"
       ]
     },
     {

--- a/docs/terms.txt
+++ b/docs/terms.txt
@@ -127,6 +127,7 @@ role:framework
 role:language
 role:library
 role:linter
+role:native-extension
 role:orchestrator
 role:package-manager
 role:plugin

--- a/oss-taxonomy/role/native-extension.yml
+++ b/oss-taxonomy/role/native-extension.yml
@@ -1,5 +1,5 @@
 name: native-extension
-description: Packages that compile C, C++, or Rust into a shared object the host language runtime loads at import time.
+description: Packages that load compiled C, C++, or Rust code as a shared library (.so/.dylib/.dll) into the host language runtime at import time, whether built from bundled source during install or shipped as a prebuilt binary.
 examples:
   - nokogiri
   - numpy

--- a/oss-taxonomy/role/native-extension.yml
+++ b/oss-taxonomy/role/native-extension.yml
@@ -1,0 +1,30 @@
+name: native-extension
+description: Packages that compile C, C++, or Rust into a shared object the host language runtime loads at import time.
+examples:
+  - nokogiri
+  - numpy
+  - psycopg2
+  - node-sass
+  - bcrypt
+  - grpcio
+related:
+  - library
+  - plugin
+  - build-tool
+aliases:
+  - c-extension
+  - native-addon
+  - ffi-binding
+  - compiled-extension
+ecosystems:
+  - rubygems
+  - pypi
+  - npm
+  - packagist
+  - hex
+  - cpan
+tags:
+  - ffi
+  - native
+  - compiled
+  - binding

--- a/terms.txt
+++ b/terms.txt
@@ -127,6 +127,7 @@ role:framework
 role:language
 role:library
 role:linter
+role:native-extension
 role:orchestrator
 role:package-manager
 role:plugin


### PR DESCRIPTION
Packages that compile C/C++/Rust into a shared object the host language runtime loads at import time. Examples: nokogiri, numpy, psycopg2, node-sass, bcrypt, grpcio. Aliases: c-extension, native-addon, ffi-binding, compiled-extension.

Fills a gap between `library` (any reusable code) and `build-tool` (make/cmake): there was no term for "library that ships compiled native code", which matters for supply-chain classification since these packages run a compiler at install time and load a `.so`/`.dylib`/`.dll` at runtime.

`git-pkgs/brief` #108 adds a `native_extension` detection category (mkmf, phpize, node-gyp, setuptools Extension) and will pick this term up once `terms.txt` is refreshed.

Regenerated `combined-taxonomy.json`, `terms.txt` and `docs/` copies via `ruby combine_yml_to_json.rb`.