### PR TITLE
Add external taxonomy source collectors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  pull_request:
+    paths:
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - 'scripts/**/*.rb'
+      - 'test/**/*.rb'
+      - '.github/workflows/test.yml'
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec ruby -Itest test/external_sources_test.rb

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/data/external/stackshare-tools.csv

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'yaml'
 gem 'json'
+gem 'csv'
+gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,10 @@ DEPENDENCIES
 
 CHECKSUMS
   bundler (4.0.19) sha256=b48056e4c77fb3853cc47775b5447ede44aaa4f53c32f168014ab4fe86587d47
-  csv (3.3.6)
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
-  power_assert (3.0.1)
-  test-unit (3.7.5)
+  power_assert (3.0.1) sha256=8ce9876716cc74e863fcd4cdcdc52d792bd983598d1af3447083a3a9a4d34103
+  test-unit (3.7.5) sha256=f36c28b6c13bb974dd3553bb9f2b25534e62baf8e55960d4481b27f2b4d10295
   yaml (0.4.0) sha256=240e69d1e6ce3584d6085978719a0faa6218ae426e034d8f9b02fb54d3471942
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    csv (3.3.6)
     json (2.21.2)
+    power_assert (3.0.1)
+    test-unit (3.7.5)
+      power_assert
     yaml (0.4.0)
 
 PLATFORMS
@@ -9,12 +13,17 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  csv
   json
+  test-unit
   yaml
 
 CHECKSUMS
   bundler (4.0.19) sha256=b48056e4c77fb3853cc47775b5447ede44aaa4f53c32f168014ab4fe86587d47
+  csv (3.3.6)
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  power_assert (3.0.1)
+  test-unit (3.7.5)
   yaml (0.4.0) sha256=240e69d1e6ce3584d6085978719a0faa6218ae426e034d8f9b02fb54d3471942
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ A combined JSON file is automatically generated ([`combined-taxonomy.json`](./co
 
 The taxonomy structure is formally defined in [`schema.json`](./schema.json), a JSON Schema file that can be used to validate the combined taxonomy data or integrate it into your tools and editors.
 
+### External source collectors
+
+The collector CLI emits normalized records from public category and tag sources. List the supported sources, then select JSON, JSON Lines, or TSV output:
+
+```sh
+bundle exec ruby scripts/collect_external_source.rb --list
+bundle exec ruby scripts/collect_external_source.rb pypi-classifiers --kind topic --format tsv
+```
+
+Use `--input PATH_OR_URL` to parse a saved response. The StackShare collector reads `data/external/stackshare-tools.csv` when that file exists and downloads the [published dataset](https://github.com/captn3m0/stackshare-dataset) otherwise. The local snapshot is ignored by Git because the source database is distributed under the ODbL.
+
 ## Using with CodeMeta
 
 [CodeMeta](https://codemeta.github.io/) is a standard for software metadata that extends schema.org. If you're maintaining a `codemeta.json` file for your project, you can use this taxonomy to provide rich, structured classification.

--- a/scripts/collect_external_source.rb
+++ b/scripts/collect_external_source.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'optparse'
 require_relative 'external_sources'
 

--- a/scripts/collect_external_source.rb
+++ b/scripts/collect_external_source.rb
@@ -1,0 +1,32 @@
+require 'optparse'
+require_relative 'external_sources'
+
+options = {
+  format: 'json',
+  limit: nil,
+  input: nil,
+  kind: nil
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = 'Usage: bundle exec ruby scripts/collect_external_source.rb SOURCE [options]'
+  opts.on('--format FORMAT', 'json, jsonl, or tsv') { |value| options[:format] = value }
+  opts.on('--input PATH_OR_URL', 'Read source data from a local file or URL') { |value| options[:input] = value }
+  opts.on('--kind KIND', 'Keep records with this kind') { |value| options[:kind] = value }
+  opts.on('--limit COUNT', Integer, 'Limit the number of records') { |value| options[:limit] = value }
+  opts.on('--list', 'List available sources') do
+    puts ExternalSources.names
+    exit
+  end
+end
+
+parser.parse!
+source = ARGV.shift
+abort parser.to_s unless source
+
+collector_limit = options[:kind] && ExternalSources.multiple_kinds?(source) ? nil : options[:limit]
+collector = ExternalSources.build(source, limit: collector_limit)
+records = collector.collect(input: options[:input])
+records = records.select { |record| record['kind'] == options[:kind] } if options[:kind]
+records = records.first(options[:limit]) if options[:kind] && options[:limit]
+puts ExternalSources::Formatter.render(records, options[:format])

--- a/scripts/external_sources.rb
+++ b/scripts/external_sources.rb
@@ -1,0 +1,396 @@
+require 'cgi/escape'
+require 'csv'
+require 'json'
+require 'net/http'
+require 'uri'
+
+module ExternalSources
+  USER_AGENT = 'oss-taxonomy external source collector (https://github.com/ecosyste-ms/oss-taxonomy)'
+
+  class HTTPClient
+    def get(url, redirects: 3)
+      uri = URI(url)
+      request = Net::HTTP::Get.new(uri)
+      request['User-Agent'] = USER_AGENT
+
+      response = Net::HTTP.start(
+        uri.host,
+        uri.port,
+        use_ssl: uri.scheme == 'https',
+        open_timeout: 15,
+        read_timeout: 120
+      ) { |http| http.request(request) }
+
+      return response.body if response.is_a?(Net::HTTPSuccess)
+
+      if response.is_a?(Net::HTTPRedirection) && redirects.positive?
+        return get(URI.join(url, response['location']).to_s, redirects: redirects - 1)
+      end
+
+      raise "#{response.code} #{response.message} for #{url}"
+    end
+  end
+
+  module Input
+    def self.read(value, client)
+      return client.get(value) if value.match?(/\Ahttps?:\/\//)
+
+      File.read(value)
+    end
+  end
+
+  module Text
+    def self.clean_html(value)
+      text = value.to_s.dup.force_encoding(Encoding::UTF_8).scrub
+      CGI.unescapeHTML(text.gsub(/<[^>]+>/, '').tr("\u00A0", ' ').strip)
+    end
+
+    def self.slug(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]+/, '-').gsub(/\A-|\-\z/, '')
+    end
+  end
+
+  class PyPIClassifiers
+    URL = 'https://pypi.org/classifiers/'
+
+    def initialize(client: HTTPClient.new, limit: nil)
+      @client = client
+      @limit = limit
+    end
+
+    def collect(input: nil)
+      parse(input ? Input.read(input, @client) : @client.get(URL))
+    end
+
+    def parse(html)
+      classifiers = html.scan(/<a[^>]+data-clipboard-target="source"[^>]*>(.*?)<\/a>/m).flatten
+
+      classifiers.map do |classifier|
+        classifier = Text.clean_html(classifier)
+        path = classifier.split(' :: ')
+        {
+          'source' => 'pypi',
+          'kind' => Text.slug(path.first),
+          'id' => classifier,
+          'label' => path.last,
+          'path' => path,
+          'url' => "https://pypi.org/search/?#{URI.encode_www_form(c: classifier)}"
+        }
+      end.first(@limit || classifiers.length)
+    end
+  end
+
+  class CratesCategories
+    URL = 'https://crates.io/api/v1/categories?page=1&per_page=100'
+
+    def initialize(client: HTTPClient.new, limit: nil)
+      @client = client
+      @limit = limit
+    end
+
+    def collect(input: nil)
+      parse(input ? Input.read(input, @client) : @client.get(URL))
+    end
+
+    def parse(body)
+      JSON.parse(body).fetch('categories').map do |category|
+        {
+          'source' => 'crates.io',
+          'kind' => 'category',
+          'id' => category.fetch('slug'),
+          'label' => category.fetch('category'),
+          'count' => category.fetch('crates_cnt'),
+          'description' => category['description'],
+          'url' => "https://crates.io/categories/#{category.fetch('slug')}"
+        }.compact
+      end.first(@limit || 100)
+    end
+  end
+
+  class OpenAlexFields
+    URL = 'https://api.openalex.org/fields?per-page=100'
+
+    def initialize(client: HTTPClient.new, limit: nil)
+      @client = client
+      @limit = limit
+    end
+
+    def collect(input: nil)
+      parse(input ? Input.read(input, @client) : @client.get(URL))
+    end
+
+    def parse(body)
+      records = {}
+
+      JSON.parse(body).fetch('results').each do |field|
+        domain = field.fetch('domain')
+        records[['domain', domain.fetch('id')]] ||= {
+          'source' => 'openalex',
+          'kind' => 'domain',
+          'id' => domain.fetch('id'),
+          'label' => domain.fetch('display_name'),
+          'path' => [domain.fetch('display_name')],
+          'url' => domain.fetch('id')
+        }
+
+        records[['field', field.fetch('id')]] = {
+          'source' => 'openalex',
+          'kind' => 'field',
+          'id' => field.fetch('id'),
+          'label' => field.fetch('display_name'),
+          'path' => [domain.fetch('display_name'), field.fetch('display_name')],
+          'count' => field['works_count'],
+          'description' => field['description'],
+          'url' => field.fetch('id')
+        }.compact
+
+        Array(field['subfields']).each do |subfield|
+          records[['subfield', subfield.fetch('id')]] = {
+            'source' => 'openalex',
+            'kind' => 'subfield',
+            'id' => subfield.fetch('id'),
+            'label' => subfield.fetch('display_name'),
+            'path' => [domain.fetch('display_name'), field.fetch('display_name'), subfield.fetch('display_name')],
+            'url' => subfield.fetch('id')
+          }
+        end
+      end
+
+      records.values.first(@limit || records.length)
+    end
+  end
+
+  class WikidataSoftwareClasses
+    ENDPOINT = 'https://query.wikidata.org/sparql'
+    QUERY = <<~SPARQL.freeze
+      SELECT ?class ?classLabel (COUNT(?software) AS ?count)
+      WHERE {
+        ?class wdt:P279 wd:Q7397.
+        ?software wdt:P31 ?class.
+        SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
+      }
+      GROUP BY ?class ?classLabel
+      ORDER BY DESC(?count)
+      LIMIT %<limit>d
+    SPARQL
+
+    def initialize(client: HTTPClient.new, limit: 200)
+      @client = client
+      @limit = limit || 200
+    end
+
+    def collect(input: nil)
+      return parse(Input.read(input, @client)) if input
+
+      query = format(QUERY, limit: @limit)
+      url = "#{ENDPOINT}?#{URI.encode_www_form(format: 'json', query: query)}"
+      parse(@client.get(url))
+    end
+
+    def parse(body)
+      JSON.parse(body).dig('results', 'bindings').map do |binding|
+        entity_url = binding.dig('class', 'value').sub('http://', 'https://')
+        {
+          'source' => 'wikidata',
+          'kind' => 'software-class',
+          'id' => entity_url.split('/').last,
+          'label' => binding.dig('classLabel', 'value'),
+          'count' => binding.dig('count', 'value').to_i,
+          'url' => entity_url
+        }
+      end.first(@limit)
+    end
+  end
+
+  class StackOverflowTags
+    ENDPOINT = 'https://api.stackexchange.com/2.3/tags'
+
+    def initialize(client: HTTPClient.new, limit: 100)
+      @client = client
+      @limit = limit || 100
+    end
+
+    def collect(input: nil)
+      return parse(Input.read(input, @client)).first(@limit) if input
+
+      records = []
+      page = 1
+
+      while records.length < @limit
+        per_page = [@limit - records.length, 100].min
+        query = URI.encode_www_form(site: 'stackoverflow', sort: 'popular', order: 'desc', pagesize: per_page, page: page)
+        body = @client.get("#{ENDPOINT}?#{query}")
+        parsed = JSON.parse(body)
+        records.concat(parse(body))
+        break unless parsed['has_more']
+
+        page += 1
+      end
+
+      records.first(@limit)
+    end
+
+    def parse(body)
+      JSON.parse(body).fetch('items').map do |tag|
+        name = tag.fetch('name')
+        {
+          'source' => 'stackoverflow',
+          'kind' => 'tag',
+          'id' => name,
+          'label' => name,
+          'count' => tag.fetch('count'),
+          'url' => "https://stackoverflow.com/questions/tagged/#{URI.encode_www_form_component(name)}"
+        }
+      end
+    end
+  end
+
+  class FreeDesktopCategories
+    MAIN_URL = 'https://specifications.freedesktop.org/menu/latest/category-registry.html'
+    ADDITIONAL_URL = 'https://specifications.freedesktop.org/menu/latest/additional-category-registry.html'
+
+    def initialize(client: HTTPClient.new, limit: nil)
+      @client = client
+      @limit = limit
+    end
+
+    def collect(input: nil)
+      records = if input
+        body = Input.read(input, @client)
+        kind = body.match?(/<th[^>]*>Main Category<\/th>/) ? 'main-category' : 'additional-category'
+        url = kind == 'main-category' ? MAIN_URL : ADDITIONAL_URL
+        parse_table(body, kind, url)
+      else
+        parse_table(@client.get(MAIN_URL), 'main-category', MAIN_URL) +
+          parse_table(@client.get(ADDITIONAL_URL), 'additional-category', ADDITIONAL_URL)
+      end
+
+      records.first(@limit || records.length)
+    end
+
+    def parse_table(html, kind, url)
+      html.scan(/<tr>(.*?)<\/tr>/m).filter_map do |row_match|
+        cells = row_match.first.scan(/<t[dh][^>]*>(.*?)<\/t[dh]>/m).flatten.map { |cell| Text.clean_html(cell) }
+        next if cells.length < 2 || cells.first.match?(/Category\z/)
+
+        record = {
+          'source' => 'freedesktop',
+          'kind' => kind,
+          'id' => cells.first,
+          'label' => cells.first,
+          'description' => cells[1],
+          'url' => url
+        }
+
+        details = cells.fetch(2, '')
+        if kind == 'main-category'
+          record['notes'] = details unless details.empty?
+        else
+          record['related'] = details.split(/\s+or\s+|;/).map(&:strip).reject(&:empty?)
+        end
+
+        record
+      end
+    end
+  end
+
+  class StackShareCategories
+    URL = 'https://raw.githubusercontent.com/captn3m0/stackshare-dataset/main/tools.csv'
+    LOCAL_PATH = File.expand_path('../data/external/stackshare-tools.csv', __dir__)
+
+    def initialize(client: HTTPClient.new, limit: nil, local_path: LOCAL_PATH)
+      @client = client
+      @limit = limit
+      @local_path = local_path
+    end
+
+    def collect(input: nil)
+      source = input || (File.exist?(@local_path) ? @local_path : URL)
+      parse(Input.read(source, @client))
+    end
+
+    def parse(body)
+      rows = CSV.parse(body, headers: true)
+      records = %w[category layer function].flat_map do |kind|
+        rows.group_by { |row| row[kind] }.filter_map do |label, matches|
+          next if label.nil? || label.empty?
+
+          examples = matches.sort_by { |row| -row['popularity'].to_f }.first(5).map { |row| row['name'] }
+          {
+            'source' => 'stackshare',
+            'kind' => kind,
+            'id' => label,
+            'label' => label,
+            'count' => matches.length,
+            'examples' => examples,
+            'metrics' => { 'popularity' => matches.sum { |row| row['popularity'].to_f }.round(1) },
+            'url' => 'https://github.com/captn3m0/stackshare-dataset'
+          }
+        end
+      end
+
+      records.sort_by { |record| [record.fetch('kind'), -record.fetch('count'), record.fetch('label')] }
+        .first(@limit || records.length)
+    end
+  end
+
+  SOURCES = {
+    'crates-categories' => CratesCategories,
+    'freedesktop-categories' => FreeDesktopCategories,
+    'openalex-fields' => OpenAlexFields,
+    'pypi-classifiers' => PyPIClassifiers,
+    'stackoverflow-tags' => StackOverflowTags,
+    'stackshare-categories' => StackShareCategories,
+    'wikidata-software-classes' => WikidataSoftwareClasses
+  }.freeze
+  MULTI_KIND_SOURCES = %w[
+    freedesktop-categories
+    openalex-fields
+    pypi-classifiers
+    stackshare-categories
+  ].freeze
+
+  def self.names
+    SOURCES.keys.sort
+  end
+
+  def self.build(name, limit: nil, client: HTTPClient.new)
+    collector = SOURCES[name]
+    raise ArgumentError, "Unknown source: #{name}" unless collector
+
+    collector.new(client: client, limit: limit)
+  end
+
+  def self.multiple_kinds?(name)
+    MULTI_KIND_SOURCES.include?(name)
+  end
+
+  module Formatter
+    def self.render(records, format)
+      case format
+      when 'json'
+        JSON.pretty_generate(records)
+      when 'jsonl'
+        records.map { |record| JSON.generate(record) }.join("\n")
+      when 'tsv'
+        CSV.generate(col_sep: "\t") do |csv|
+          csv << %w[source kind id label count path description url]
+          records.each do |record|
+            csv << [
+              record['source'],
+              record['kind'],
+              record['id'],
+              record['label'],
+              record['count'],
+              Array(record['path']).join(' > '),
+              record['description'],
+              record['url']
+            ]
+          end
+        end
+      else
+        raise ArgumentError, "Unknown format: #{format}"
+      end
+    end
+  end
+end

--- a/scripts/external_sources.rb
+++ b/scripts/external_sources.rb
@@ -234,7 +234,7 @@ module ExternalSources
         query = URI.encode_www_form(site: 'stackoverflow', sort: 'popular', order: 'desc', pagesize: per_page, page: page)
         body = @client.get("#{ENDPOINT}?#{query}")
         parsed = JSON.parse(body)
-        records.concat(parse(body))
+        records.concat(records_from(parsed))
         break unless parsed['has_more']
 
         page += 1
@@ -244,7 +244,11 @@ module ExternalSources
     end
 
     def parse(body)
-      JSON.parse(body).fetch('items').map do |tag|
+      records_from(JSON.parse(body))
+    end
+
+    def records_from(payload)
+      payload.fetch('items').map do |tag|
         name = tag.fetch('name')
         {
           'source' => 'stackoverflow',

--- a/scripts/external_sources.rb
+++ b/scripts/external_sources.rb
@@ -41,8 +41,21 @@ module ExternalSources
 
   module Text
     def self.clean_html(value)
-      text = value.to_s.dup.force_encoding(Encoding::UTF_8).scrub
-      CGI.unescapeHTML(text.gsub(/<[^>]+>/, '').tr("\u00A0", ' ').strip)
+      text = CGI.unescapeHTML(value.to_s.dup.force_encoding(Encoding::UTF_8).scrub)
+      plain_text = +''
+      inside_tag = false
+
+      text.each_char do |character|
+        if character == '<'
+          inside_tag = true
+        elsif inside_tag
+          inside_tag = false if character == '>'
+        else
+          plain_text << character
+        end
+      end
+
+      plain_text.tr("\u00A0", ' ').strip
     end
 
     def self.slug(value)

--- a/test/external_sources_test.rb
+++ b/test/external_sources_test.rb
@@ -1,0 +1,168 @@
+require 'test/unit'
+require 'open3'
+require 'rbconfig'
+require 'tempfile'
+require_relative '../scripts/external_sources'
+
+class ExternalSourcesTest < Test::Unit::TestCase
+  def test_pypi_classifiers_preserve_hierarchy
+    html = <<~HTML
+      <a href="/search/?c=Topic" data-clipboard-target="source">Topic :: Scientific/Engineering :: Physics</a>
+      <a href="/search/?c=Audience" data-clipboard-target="source">Intended Audience :: Developers</a>
+    HTML
+
+    records = ExternalSources::PyPIClassifiers.new.parse(html)
+
+    assert_equal 2, records.length
+    assert_equal 'topic', records[0]['kind']
+    assert_equal ['Topic', 'Scientific/Engineering', 'Physics'], records[0]['path']
+    assert_equal 'developers', records[1]['label'].downcase
+  end
+
+  def test_crates_categories_include_counts
+    body = JSON.generate('categories' => [{
+      'slug' => 'accessibility',
+      'category' => 'Accessibility',
+      'description' => 'Assistive technology.',
+      'crates_cnt' => 613
+    }])
+
+    record = ExternalSources::CratesCategories.new.parse(body).first
+
+    assert_equal 'accessibility', record['id']
+    assert_equal 613, record['count']
+  end
+
+  def test_openalex_fields_emit_domain_field_and_subfield_records
+    body = JSON.generate('results' => [{
+      'id' => 'https://openalex.org/fields/22',
+      'display_name' => 'Engineering',
+      'description' => 'Engineering research.',
+      'works_count' => 10,
+      'domain' => { 'id' => 'https://openalex.org/domains/3', 'display_name' => 'Physical Sciences' },
+      'subfields' => [{ 'id' => 'https://openalex.org/subfields/2202', 'display_name' => 'Aerospace Engineering' }]
+    }])
+
+    records = ExternalSources::OpenAlexFields.new.parse(body)
+
+    assert_equal %w[domain field subfield], records.map { |record| record['kind'] }
+    assert_equal ['Physical Sciences', 'Engineering', 'Aerospace Engineering'], records.last['path']
+  end
+
+  def test_wikidata_software_classes_extract_entity_ids
+    body = JSON.generate('results' => { 'bindings' => [{
+      'class' => { 'value' => 'http://www.wikidata.org/entity/Q1403556' },
+      'classLabel' => { 'value' => 'reference management software' },
+      'count' => { 'value' => '57' }
+    }] })
+
+    record = ExternalSources::WikidataSoftwareClasses.new.parse(body).first
+
+    assert_equal 'Q1403556', record['id']
+    assert_equal 57, record['count']
+  end
+
+  def test_stackoverflow_tags_include_question_counts
+    body = JSON.generate('items' => [{ 'name' => 'matlab', 'count' => 94_518 }])
+
+    record = ExternalSources::StackOverflowTags.new.parse(body).first
+
+    assert_equal 'matlab', record['id']
+    assert_equal 94_518, record['count']
+  end
+
+  def test_freedesktop_categories_preserve_related_categories
+    html = (<<~HTML).b
+      <table><tbody>
+        <tr><td>ProjectManagement</td><td>Project management application</td><td>Office or Development</td></tr>
+      </tbody></table>
+    HTML
+
+    record = ExternalSources::FreeDesktopCategories.new.parse_table(html, 'additional-category', 'https://example.test').first
+
+    assert_equal 'ProjectManagement', record['id']
+    assert_equal ['Office', 'Development'], record['related']
+  end
+
+  def test_freedesktop_main_categories_preserve_notes
+    html = '<table><tr><td>Audio</td><td>An audio application</td><td>Desktop entry must include AudioVideo as well</td></tr></table>'.b
+
+    record = ExternalSources::FreeDesktopCategories.new.parse_table(html, 'main-category', 'https://example.test').first
+
+    assert_equal 'Desktop entry must include AudioVideo as well', record['notes']
+    assert_nil record['related']
+  end
+
+  def test_freedesktop_categories_identify_a_saved_main_category_page
+    Tempfile.create(['freedesktop-main', '.html']) do |file|
+      file.write('<table><thead><tr><th>Main Category</th><th>Description</th><th>Notes</th></tr></thead><tbody><tr><td>Science</td><td>Scientific software</td><td></td></tr></tbody></table>')
+      file.flush
+
+      record = ExternalSources::FreeDesktopCategories.new.collect(input: file.path).first
+
+      assert_equal 'main-category', record['kind']
+      assert_equal ExternalSources::FreeDesktopCategories::MAIN_URL, record['url']
+    end
+  end
+
+  def test_stackshare_categories_aggregate_counts_and_examples
+    csv = <<~CSV
+      name,popularity,category,layer,function
+      Git,10,build-test-deploy,devops,version-control-system
+      Mercurial,5,build-test-deploy,devops,version-control-system
+      Docker,8,build-test-deploy,devops,container-tools
+    CSV
+
+    records = ExternalSources::StackShareCategories.new.parse(csv)
+    function = records.find { |record| record['id'] == 'version-control-system' }
+
+    assert_equal 2, function['count']
+    assert_equal ['Git', 'Mercurial'], function['examples']
+    assert_equal 15.0, function.dig('metrics', 'popularity')
+  end
+
+  def test_stackshare_categories_prefer_the_local_snapshot
+    Tempfile.create(['stackshare-tools', '.csv']) do |file|
+      file.write(<<~CSV)
+        name,popularity,category,layer,function
+        Git,10,build-test-deploy,devops,version-control-system
+      CSV
+      file.flush
+
+      records = ExternalSources::StackShareCategories.new(client: Object.new, local_path: file.path).collect
+
+      assert_equal %w[category function layer], records.map { |record| record['kind'] }
+    end
+  end
+
+  def test_formatter_supports_json_lines
+    rendered = ExternalSources::Formatter.render([{ 'source' => 'test', 'kind' => 'tag', 'id' => 'ruby', 'label' => 'ruby' }], 'jsonl')
+
+    assert_equal({ 'source' => 'test', 'kind' => 'tag', 'id' => 'ruby', 'label' => 'ruby' }, JSON.parse(rendered))
+  end
+
+  def test_cli_collects_and_filters_a_local_source
+    Tempfile.create(['stackshare-tools', '.csv']) do |file|
+      file.write(<<~CSV)
+        name,popularity,category,layer,function
+        Git,10,build-test-deploy,devops,version-control-system
+        Docker,8,build-test-deploy,devops,container-tools
+      CSV
+      file.flush
+
+      script = File.expand_path('../scripts/collect_external_source.rb', __dir__)
+      stdout, stderr, status = Open3.capture3(
+        RbConfig.ruby,
+        script,
+        'stackshare-categories',
+        '--input', file.path,
+        '--kind', 'function',
+        '--limit', '1',
+        '--format', 'json'
+      )
+
+      assert_predicate status, :success?, stderr
+      assert_equal ['container-tools'], JSON.parse(stdout).map { |record| record['id'] }
+    end
+  end
+end

--- a/test/external_sources_test.rb
+++ b/test/external_sources_test.rb
@@ -5,6 +5,14 @@ require 'tempfile'
 require_relative '../scripts/external_sources'
 
 class ExternalSourcesTest < Test::Unit::TestCase
+  def test_clean_html_removes_nested_and_encoded_tags
+    nested = ExternalSources::Text.clean_html('before<<script>alert(1)</script>after')
+    encoded = ExternalSources::Text.clean_html('before&lt;script&gt;alert(1)&lt;/script&gt;after')
+
+    assert_equal 'beforealert(1)after', nested
+    assert_equal 'beforealert(1)after', encoded
+  end
+
   def test_pypi_classifiers_preserve_hierarchy
     html = <<~HTML
       <a href="/search/?c=Topic" data-clipboard-target="source">Topic :: Scientific/Engineering :: Physics</a>


### PR DESCRIPTION
Add a reusable Ruby CLI for collecting normalized category and tag records from PyPI, crates.io, OpenAlex, Wikidata, Stack Overflow, FreeDesktop, and StackShare.

The collectors support JSON, JSON Lines, and TSV output, local or remote inputs, kind filtering, and record limits. StackShare uses an ignored local `data/external/stackshare-tools.csv` snapshot when present, with the published dataset as fallback.

Add parser and CLI coverage plus a pull request workflow for the collector suite.